### PR TITLE
Fix UserImport ID collection to avoid overwriting and skipped users

### DIFF
--- a/classes/Job/UserImportJob.php
+++ b/classes/Job/UserImportJob.php
@@ -222,7 +222,7 @@ class UserImportJob extends ilCronJob
             $attachments = [];
             if ($report->hasErrors()) {
                 $tmp_filename = ilFileUtils::ilTempnam() . '.csv';
-                file_put_contents($tmp_filename, $report->asText());
+                file_put_contents($tmp_filename, "\xEF\xBB\xBF" . $report->asText()); // Prefix with UTF-8 BOM for Excel compatibility
 
                 $filename = ilFileUtils::getASCIIFilename(implode('_', [
                         $this->plugin->txt('report_export_name'),
@@ -285,7 +285,7 @@ class UserImportJob extends ilCronJob
         $cron_result->setStatus(ilCronJobResult::STATUS_OK);
         $cron_result->setMessage(
             \sprintf(
-                $this->plugin->txt('cron_result'),
+                $this->plugin->txt('cronResult'),
                 \count($user_imports),
                 $num_failed_mail_deliveries
             )

--- a/classes/Services/UserImportService.php
+++ b/classes/Services/UserImportService.php
@@ -202,25 +202,21 @@ class UserImportService
                 continue;
             }
 
-            $usr_id = ilObjUser::getUserIdByLogin($user_identifier);
-            if ($usr_id > 0) {
-                $usr_ids[] = $usr_id;
+            $by_login = ilObjUser::getUserIdByLogin($user_identifier);
+            if ($by_login > 0) {
+                $usr_ids[] = $by_login;
                 continue;
             }
 
-            $usr_ids = ilObjUser::getUserIdsByEmail($user_identifier);
-            if (\count($usr_ids) === 1) {
-                foreach ($usr_ids as $usr_id) {
-                    $usr_ids[] = $usr_id;
-                }
+            $by_email = ilObjUser::getUserIdsByEmail($user_identifier);
+            if (count($by_email) === 1) {
+                $usr_ids[] = $by_email[0];
                 continue;
             }
 
-            $usr_ids = $user_import_repo->getUserIdsByMatriculation($user_identifier);
-            if (\count($usr_ids) === 1) {
-                foreach ($usr_ids as $usr_id) {
-                    $usr_ids[] = $usr_id;
-                }
+            $by_matric = $user_import_repo->getUserIdsByMatriculation($user_identifier);
+            if (count($by_matric) === 1) {
+                $usr_ids[] = $by_matric[0];
                 continue;
             }
 


### PR DESCRIPTION
Previously, the array used to collect user IDs was overwritten when looking up users by email or matriculation number, causing the first valid users to be skipped if a later identifier was invalid.  

This change separates temporary lookup variables (by_login, by_email, by_matric) from the main $usr_ids array and only appends valid unique IDs. This ensures all valid users are processed correctly, regardless of order, and invalid users are properly logged in the report.

Also adds UTF-8 BOM for Excel compatibility.
Also fixes an translation key.