### PR TITLE
Status-Update der User-Importe repariert

### DIFF
--- a/classes/Repositories/UserImportRepository.php
+++ b/classes/Repositories/UserImportRepository.php
@@ -68,11 +68,11 @@ class UserImportRepository
         $this->db->manipulateF(
             '
                 UPDATE ' . self::TABLE_NAME . ' SET
-                status = %s,
+                status = %s
                 WHERE id = %s
             ',
             ['integer', 'integer'],
-            [$userImport->getStatus(), $userImport->getStatus()]
+            [$userImport->getStatus(), (int) $userImport->getId()]
         );
     }
 


### PR DESCRIPTION
Korrigiert einen Syntaxfehler (überflüssiges Komma) in der UPDATE-Query der Methode updateStatus.

Zudem wurde das fehlerhafte Parameter-Binding behoben, bei dem der Status anstelle der Datensatz-ID für die WHERE-Bedingung verwendet wurde.